### PR TITLE
feat(security): Implement rate limiting on login endpoint

### DIFF
--- a/medverse-backend/pom.xml
+++ b/medverse-backend/pom.xml
@@ -99,6 +99,16 @@
 			<version>2.5.0</version>
 		</dependency>
 		<dependency>
+			<groupId>com.github.vladimir-bukhtoyarov</groupId>
+			<artifactId>bucket4j-core</artifactId>
+			<version>8.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.vladimir-bukhtoyarov</groupId>
+			<artifactId>bucket4j-jcache</artifactId>
+			<version>8.0.1</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
 		</dependency>

--- a/medverse-backend/src/main/java/com/medverse/backend/config/CustomAuthEntryPoint.java
+++ b/medverse-backend/src/main/java/com/medverse/backend/config/CustomAuthEntryPoint.java
@@ -1,0 +1,36 @@
+package com.medverse.backend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.medverse.backend.payload.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class CustomAuthEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException) throws IOException, ServletException {
+
+        log.error("Unauthorized error: {}", authException.getMessage());
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ApiResponse<Object> body = new ApiResponse<>("ERROR", "Authentication Failed: " + authException.getMessage(),
+                null, null);
+
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), body);
+    }
+}

--- a/medverse-backend/src/main/java/com/medverse/backend/config/RateLimitFilter.java
+++ b/medverse-backend/src/main/java/com/medverse/backend/config/RateLimitFilter.java
@@ -1,0 +1,69 @@
+package com.medverse.backend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.medverse.backend.payload.ApiResponse;
+import com.medverse.backend.service.RateLimitService;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private final RateLimitService rateLimitService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        if (!request.getRequestURI().startsWith("/api/auth/login")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String ipAddress = getClientIp(request);
+        Bucket tokenBucket = rateLimitService.resolveBucket(ipAddress);
+        ConsumptionProbe probe = tokenBucket.tryConsumeAndReturnRemaining(1);
+
+        if (probe.isConsumed()) {
+            response.addHeader("X-Rate-Limit-Remaining", String.valueOf(probe.getRemainingTokens()));
+            filterChain.doFilter(request, response);
+        } else {
+            long waitForRefill = probe.getNanosToWaitForRefill() / 1_000_000_000;
+            log.warn("Rate limit exceeded for IP: {}", ipAddress);
+
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            response.addHeader("X-Rate-Limit-Retry-After-Seconds", String.valueOf(waitForRefill));
+
+            ApiResponse<Object> body = new ApiResponse<>("ERROR", "You have exhausted your API request quota", null,
+                    null);
+            response.getWriter().write(objectMapper.writeValueAsString(body));
+        }
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getRemoteAddr();
+        }
+        return ip.split(",")[0].trim();
+    }
+}

--- a/medverse-backend/src/main/java/com/medverse/backend/config/SecurityConfig.java
+++ b/medverse-backend/src/main/java/com/medverse/backend/config/SecurityConfig.java
@@ -17,18 +17,24 @@ public class SecurityConfig {
 
     private final JwtAuthFilter jwtAuthFilter;
     private final AuthenticationProvider authenticationProvider;
+    private final CustomAuthEntryPoint customAuthEntryPoint;
+    private final RateLimitFilter rateLimitFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .anonymous(anonymous -> anonymous.disable())
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(customAuthEntryPoint))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**")
                         .permitAll()
                         .anyRequest().authenticated())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authenticationProvider(authenticationProvider)
+
+                .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/medverse-backend/src/main/java/com/medverse/backend/service/RateLimitService.java
+++ b/medverse-backend/src/main/java/com/medverse/backend/service/RateLimitService.java
@@ -1,0 +1,27 @@
+package com.medverse.backend.service;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class RateLimitService {
+    private final Map<String, Bucket> cache = new ConcurrentHashMap<>();
+
+    public Bucket resolveBucket(String ipAddress) {
+        return cache.computeIfAbsent(ipAddress, this::newBucket);
+    }
+
+    private Bucket newBucket(String ipAddress) {
+        Bandwidth limit = Bandwidth.classic(10, Refill.greedy(10, Duration.ofMinutes(1)));
+
+        return Bucket.builder()
+                .addLimit(limit)
+                .build();
+    }
+}

--- a/medverse-backend/src/main/java/com/medverse/backend/utils/exception/GlobalExceptionHandler.java
+++ b/medverse-backend/src/main/java/com/medverse/backend/utils/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -46,6 +47,15 @@ public class GlobalExceptionHandler {
             WebRequest request) {
         ApiResponse<Object> response = new ApiResponse<>("ERROR", "Token refresh failed. Please log in again.",
                 ex.getMessage(), null);
+        return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ApiResponse<Object>> handleAuthenticationException(AuthenticationException ex,
+            WebRequest request) {
+        log.warn("Authentication failed: {}", ex.getMessage());
+        ApiResponse<Object> response = new ApiResponse<>("ERROR", "Authentication Failed: " + ex.getMessage(), null,
+                null);
         return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
     }
 


### PR DESCRIPTION
- Integrate Bucket4j library for rate limiting.
- Create RateLimitService and Interceptor to track requests per IP.
- Apply rate limit (10 requests/minute) specifically to /auth/login to protect against brute-force attacks.

Closes #10