### PR TITLE
test(rbac): Add unit tests for RbacService

### DIFF
--- a/medverse-backend/src/main/java/com/medverse/backend/payload/rbac/RoleCreateRequest.java
+++ b/medverse-backend/src/main/java/com/medverse/backend/payload/rbac/RoleCreateRequest.java
@@ -4,10 +4,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @Schema(description = "Request object for creating a new role")
+@AllArgsConstructor
 public class RoleCreateRequest {
 
     @Schema(description = "Unique code for the role. Uppercase letters and underscores only.", example = "FINANCE_MANAGER", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/medverse-backend/src/main/java/com/medverse/backend/payload/rbac/UpdateRolePermissionsRequest.java
+++ b/medverse-backend/src/main/java/com/medverse/backend/payload/rbac/UpdateRolePermissionsRequest.java
@@ -2,12 +2,14 @@ package com.medverse.backend.payload.rbac;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.util.Set;
 
 @Data
 @Schema(description = "Request object for updating the permissions of a role")
+@AllArgsConstructor
 public class UpdateRolePermissionsRequest {
 
     @Schema(description = "A set of permission codes to be assigned to the role. This will overwrite all existing permissions.", example = "[\"APPOINTMENT:READ_ANY\", \"APPOINTMENT:WRITE_ANY\"]", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/medverse-backend/src/main/java/com/medverse/backend/service/RbacService.java
+++ b/medverse-backend/src/main/java/com/medverse/backend/service/RbacService.java
@@ -2,6 +2,7 @@ package com.medverse.backend.service;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -89,8 +90,9 @@ public class RbacService {
         Set<Permission> foundPermissions = permissionRepository.findByCodeIn(request.getPermissionCodes());
 
         if (foundPermissions.size() != request.getPermissionCodes().size()) {
+            Set<String> invalidCodes = new HashSet<>(request.getPermissionCodes());
             Set<String> foundCodes = foundPermissions.stream().map(Permission::getCode).collect(Collectors.toSet());
-            request.getPermissionCodes().removeAll(foundCodes);
+            invalidCodes.removeAll(foundCodes);
             throw new ResourceNotFoundException("Permissions not found with codes", "codes",
                     request.getPermissionCodes().toString());
         }

--- a/medverse-backend/src/test/java/com/medverse/backend/service/RbacServiceTest.java
+++ b/medverse-backend/src/test/java/com/medverse/backend/service/RbacServiceTest.java
@@ -1,0 +1,189 @@
+package com.medverse.backend.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.medverse.backend.entity.Permission;
+import com.medverse.backend.entity.Role;
+import com.medverse.backend.payload.rbac.RoleCreateRequest;
+import com.medverse.backend.payload.rbac.RoleDto;
+import com.medverse.backend.payload.rbac.UpdateRolePermissionsRequest;
+import com.medverse.backend.repository.PermissionRepository;
+import com.medverse.backend.repository.RoleRepository;
+import com.medverse.backend.utils.exception.DuplicateResourceException;
+import com.medverse.backend.utils.exception.ResourceNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class RbacServiceTest {
+    @Mock
+    private RoleRepository roleRepository;
+
+    @Mock
+    private PermissionRepository permissionRepository;
+
+    @Mock
+    private AuditService auditService;
+
+    private RbacService rbacService;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper realObjectMapper = new ObjectMapper();
+        rbacService = new RbacService(roleRepository, permissionRepository, auditService, realObjectMapper);
+    }
+
+    @Test
+    void createRole_Success() {
+        RoleCreateRequest request = new RoleCreateRequest("TEST_ROLE", "Test Role", "A role for testing");
+
+        when(roleRepository.findByCode("TEST_ROLE")).thenReturn(Optional.empty());
+        when(roleRepository.save(any(Role.class))).thenAnswer(invocation -> {
+            Role roleToSave = invocation.getArgument(0);
+            roleToSave.setId(UUID.randomUUID());
+            return roleToSave;
+        });
+
+        RoleDto resultDto = rbacService.createRole(request);
+
+        assertNotNull(resultDto);
+        assertEquals("TEST_ROLE", resultDto.getCode());
+        assertEquals("Test Role", resultDto.getName());
+
+        verify(roleRepository, times(1)).findByCode("TEST_ROLE");
+        verify(roleRepository, times(1)).save(any(Role.class));
+        verify(auditService, times(1)).record(any(), any(), any(), any());
+    }
+
+    @Test
+    void createRole_FailsWhenCodeIsSystemReserved() {
+        RoleCreateRequest request = new RoleCreateRequest("ADMIN", "Fake Admin", "Trying to create a system role");
+
+        assertThrows(DuplicateResourceException.class, () -> {
+            rbacService.createRole(request);
+        });
+
+        verify(roleRepository, never()).save(any(Role.class));
+        verify(auditService, never()).record(any(), any(), any(), any());
+    }
+
+    @Test
+    void createRole_FailsWhenCodeAlreadyExists() {
+        RoleCreateRequest request = new RoleCreateRequest("DUPLICATE_CODE", "Duplicate Role",
+                "A role with a taken code");
+
+        when(roleRepository.findByCode("DUPLICATE_CODE")).thenReturn(Optional.of(new Role()));
+
+        assertThrows(DuplicateResourceException.class, () -> {
+            rbacService.createRole(request);
+        });
+
+        verify(roleRepository, times(1)).findByCode("DUPLICATE_CODE");
+        verify(roleRepository, never()).save(any(Role.class));
+    }
+
+    @Test
+    void deleteRole_Success() {
+        UUID testRoleId = UUID.randomUUID();
+        Role testRole = new Role(testRoleId, "CUSTOM_ROLE", "Custom Role", "A custom role to be deleted",
+                new HashSet<>(), new HashSet<>());
+
+        when(roleRepository.findById(testRoleId)).thenReturn(Optional.of(testRole));
+        when(roleRepository.isRoleAssignedToUsers(testRoleId)).thenReturn(false);
+
+        rbacService.deleteRole(testRoleId);
+
+        verify(roleRepository, times(1)).delete(testRole);
+        verify(auditService, times(1)).record(eq("DELETE_ROLE"), eq("ROLE"), eq(testRoleId.toString()), any());
+    }
+
+    @Test
+    void deleteRole_FailsForSystemRole() {
+        UUID adminRoleId = UUID.randomUUID();
+        Role adminRole = new Role(adminRoleId, "ADMIN", "Admin Role", "", new HashSet<>(), new HashSet<>());
+
+        when(roleRepository.findById(adminRoleId)).thenReturn(Optional.of(adminRole));
+
+        assertThrows(DuplicateResourceException.class, () -> {
+            rbacService.deleteRole(adminRoleId);
+        });
+
+        verify(roleRepository, never()).delete(any(Role.class));
+    }
+
+    @Test
+    void deleteRole_FailsWhenRoleIsInUse() {
+        UUID testRoleId = UUID.randomUUID();
+        Role testRole = new Role(testRoleId, "CUSTOM_ROLE", "Custom Role", "A custom role in use", new HashSet<>(),
+                new HashSet<>());
+
+        when(roleRepository.findById(testRoleId)).thenReturn(Optional.of(testRole));
+        when(roleRepository.isRoleAssignedToUsers(testRoleId)).thenReturn(true);
+
+        assertThrows(DuplicateResourceException.class, () -> {
+            rbacService.deleteRole(testRoleId);
+        });
+
+        verify(roleRepository, never()).delete(any(Role.class));
+    }
+
+    @Test
+    void updateRolePermissions_Success() {
+        UUID roleId = UUID.randomUUID();
+        Role existingRole = new Role(roleId, "TESTER", "Tester Role", "", new HashSet<>(), new HashSet<>());
+
+        Set<String> requestedCodes = Set.of("BUG:REPORT", "TEST:EXECUTE");
+        UpdateRolePermissionsRequest request = new UpdateRolePermissionsRequest(requestedCodes);
+
+        Set<Permission> foundPermissions = requestedCodes.stream()
+                .map(code -> new Permission(UUID.randomUUID(), code, "Desc for " + code))
+                .collect(Collectors.toSet());
+
+        when(roleRepository.findById(roleId)).thenReturn(Optional.of(existingRole));
+        when(permissionRepository.findByCodeIn(requestedCodes)).thenReturn(foundPermissions);
+        when(roleRepository.save(any(Role.class))).thenReturn(existingRole);
+
+        RoleDto resultDto = rbacService.updateRolePermissions(roleId, request);
+
+        assertNotNull(resultDto);
+        assertEquals(2, resultDto.getPermissions().size());
+        assertTrue(resultDto.getPermissions().stream().anyMatch(p -> p.getCode().equals("BUG:REPORT")));
+
+        verify(roleRepository, times(1)).save(existingRole);
+        verify(auditService, times(1)).record(any(), any(), any(), any());
+    }
+
+    @Test
+    void updateRolePermissions_FailsWithInvalidPermissionCode() {
+        UUID roleId = UUID.randomUUID();
+        Role existingRole = new Role(roleId, "TESTER", "Tester Role", "", new HashSet<>(), new HashSet<>());
+
+        Set<String> requestedCodes = new HashSet<>(Set.of("BUG:REPORT", "INVALID_CODE"));
+        UpdateRolePermissionsRequest request = new UpdateRolePermissionsRequest(requestedCodes);
+
+        Set<Permission> foundPermissions = Set.of(new Permission(UUID.randomUUID(), "BUG:REPORT", "Desc"));
+
+        when(roleRepository.findById(roleId)).thenReturn(Optional.of(existingRole));
+        when(permissionRepository.findByCodeIn(requestedCodes)).thenReturn(foundPermissions);
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            rbacService.updateRolePermissions(roleId, request);
+        });
+
+        verify(roleRepository, never()).save(any(Role.class));
+    }
+}


### PR DESCRIPTION
- Cover success and failure scenarios for create, update, and delete role logic.
- Verify exception handling for system roles and duplicate codes.

Closes #23